### PR TITLE
BasePath in case of "\\?\C:\wsldist\Ubuntu20.04"

### DIFF
--- a/WslSdk/Wsl.cs
+++ b/WslSdk/Wsl.cs
@@ -32,7 +32,7 @@ namespace WslSdk
                     return null;
 
                 var basePath = distroKey.GetValue("BasePath", default(string)) as string;
-                var normalizedPath = Path.GetFullPath(basePath);
+                var normalizedPath = Path.GetFullPath(basePath.Replace("\\\\?\\", ""));
 
                 var kernelCommandLine = (distroKey.GetValue("KernelCommandLine", default(string)) as string ?? string.Empty);
                 var result = new DistroRegistryInfo()


### PR DESCRIPTION
다양한 환경에서 테스트해 보면 레지스트리의 BasePath가 "\\?\" 접두사가 붙여진 경우도 있는데 그런 환경에서는 다음과 같은 예외가 발생하게 됩니다.

Unhandled Exception: System.ArgumentException: Illegal characters in path.
   at System.Security.Permissions.FileIOPermission.EmulateFileIOPermissionChecks(String fullPath)
   at System.Security.Permissions.FileIOPermission.QuickDemand(FileIOPermissionAccess access, String fullPath, Boolean checkForDuplicates, Boolean needFullPath)
   at Wslhub.Sdk.Wsl.ReadFromRegistryKey(RegistryKey lxssKey, String keyName, Nullable`1 parsedDefaultGuid)
   at Wslhub.Sdk.Wsl.<GetDistroListFromRegistry>d__5.MoveNext()
   at WinFormInit.Program.Main(String[] args)

만약, 바꾸시게 되거든 다음의 repo에 있는 소스 코드도 함께 바꿔주세요. ^^

https://github.com/wslhub/wsl-sdk-dotnet/blob/main/src/Wslhub.Sdk/Wsl.cs#L115